### PR TITLE
polish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,147 +1,105 @@
-name: python-deployment
+name: CI/CD Pipeline
 
-run-name: ${{ github.actor }} - ${{ github.ref_name}} -${{ github.sha }}
+run-name: ${{ github.actor }} – ${{ github.ref_name }} – ${{ github.sha }}
 
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      artifact:
+        description: 'Artifact to deploy (os-version)'
+        required: true
+        type: choice
+        options:
+          - ubuntu-3.8
+          - ubuntu-3.9
+          - windows-3.8
+          - windows-3.9
 
 env:
-  PythonVersion: 3.8
-  DockerImageName: todoapp
+  DockerImageName: ${{ secrets.DOCKERHUB_USERNAME }}/todoapp
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   python-ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PythonVersion: [3.8, 3.9]
+        OsType: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.OsType }}
+    concurrency:
+      group: python-ci-${{ github.sha }}-${{ matrix.OsType }}-${{ matrix.PythonVersion }}
+      cancel-in-progress: true
     defaults:
       run:
         working-directory: ./src
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ env.PythonVersion }}
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.PythonVersion }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PythonVersion }}
-
+          python-version: ${{ matrix.PythonVersion }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install coverage flake8
           pip install -r requirements.txt
-
       - name: Run tests
-        run: |
-          python manage.py test
-
-      - name: Generate Report
+        run: python manage.py test
+      - name: Coverage report
         run: |
           coverage run --source='.' manage.py test
           coverage report
-
-      - name: Linting
+      - name: Lint & complexity
         run: |
-          flake8 . --show-source --statistics --exit-zero
-
-      - name: Check Complexity
-        run: |
-          flake8 . --exit-zero --max-complexity=6
-
-      - name: Upload python artifacts
-        uses: actions/upload-artifact@v4
+          flake8 . --show-source --statistics --exit-zero --max-complexity=6
+      - uses: actions/upload-artifact@v4
+        name: Upload python artifact
         with:
-          name: python-artifacts
-          path: .
-
-      - name: Upload helm artifacts
-        if: github.ref_name == 'main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: helm-artifacts
-          path: ${{ github.workspace }}/helm-charts
-
-      - name: Upload kind cluster artifact
-        if: github.ref_name == 'main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-cluster
-          path: ${{ github.workspace }}/cluster.yml
+          name: python-artifacts-${{ matrix.OsType }}-${{ matrix.PythonVersion }}
+          path: src
 
   docker-ci:
-    name: Build and Push Image
-    runs-on: ubuntu-latest
+    name: Build & Push Docker image
     if: ${{ github.ref_name == 'main' }}
     needs: python-ci
-    steps:
-
-    - uses: actions/download-artifact@v4
-      name: Download python artifacts
-      with:
-        name: python-artifacts
-        path: .
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Build and push
-      uses: docker/build-push-action@v5
-      with:
-        push: true
-        context: ./src
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DockerImageName }}:${{ github.sha }}
-
-  helm-ci:
     runs-on: ubuntu-latest
-    needs: python-ci
-    if: github.ref_name == 'main'
-    name: Helm CI
     steps:
+      - uses: actions/checkout@v4
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build & push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          push: true
+          tags: ${{ env.DockerImageName }}:${{ github.sha }}
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: helm-artifacts
-        path: .
-
-    - name: Set Up Helm
-      uses: azure/setup-helm@v4.2.0
-
-    - name: Lint helm
-      run: helm lint ./todoapp/
-
-    - name: Template Helm
-      run: helm template todoapp ./todoapp/ -f ./todoapp/values.yaml
-
-    - name: Package Helm
-      run: helm package ./todoapp
-
-    - name: Upload Helm Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: helm-package
-        path: ./*.tgz
-
-  deploy-helm-dev:
-    name: Deploy helm to Development
+  deploy-kind-dev:
+    name: Deploy to Development (Kind)
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: docker-ci
     uses: ./.github/workflows/reusable-deployment.yml
-    needs: [helm-ci, docker-ci]
     secrets: inherit
     with:
       environment: development
-      version: ${{ github.sha }}
+      artifact: ${{ github.event.inputs.artifact }}
 
-  deploy-helm-stg:
-    name: Deploy helm to Staging
+  deploy-kind-staging:
+    name: Deploy to Staging (Kind)
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: deploy-kind-dev
     uses: ./.github/workflows/reusable-deployment.yml
-    needs: [deploy-helm-dev]
     secrets: inherit
     with:
       environment: staging
-      version: ${{ github.sha }}
-      helm-values-path: ./todoapp/values/stg.yaml
-      helm-release-name: todoapp-staging
+      artifact: ${{ github.event.inputs.artifact }}

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -1,80 +1,75 @@
-name: helm-upgrade
-run-name: ${{ github.actor }} - ${{ github.ref_name }}
+name: deploy-to-kind
+
+run-name: Deploy to ${{ inputs.environment }}
 
 on:
   workflow_call:
     inputs:
       environment:
-        required: true
-        description: 'Environment to deploy to'
-        type: string
-      version:
+        description: 'Target environment'
         required: true
         type: string
+      artifact:
+        description: 'Select artifact from matrix'
+        required: true
+        type: choice
+        options: [ubuntu-3.8, ubuntu-3.9, windows-3.8, windows-3.9]
       helm-values-path:
+        description: 'Path to Helm values'
         type: string
         default: './todoapp/values.yaml'
       helm-release-name:
-        default: todoapp
+        description: 'Helm release name'
         type: string
+        default: 'todoapp'
+
 jobs:
-    deploy-helm:
-      name: ${{ inputs.environment }}
-      runs-on: ubuntu-latest
-      environment: ${{ inputs.environment }}
+  deploy-kind:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: deploy-${{ inputs.environment }}-${{ github.ref_name }}
+      cancel-in-progress: true
 
-      steps:
-      - uses: actions/download-artifact@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download python artifact
+        uses: actions/download-artifact@v4
         with:
-          name: helm-package
-          path: .
+          name: python-artifacts-${{ inputs.artifact }}
+          path: ./src
 
-      - uses: actions/download-artifact@v4
+      - name: Download Helm package
+        uses: actions/download-artifact@v4
         with:
           name: helm-artifacts
           path: .
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: kind-cluster
-          path: .
+      - name: Install Kind CLI
+        run: |
+          curl -Lo kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x kind
+          sudo mv kind /usr/local/bin/
 
-      - name: Set Up Helm
-        uses: azure/setup-helm@v4.2.0
+      - name: Create Kind cluster
+        run: kind create cluster --config cluster.yml
 
       - name: Set up Kubectl
         uses: azure/setup-kubectl@v4
 
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
-        with:
-          config: ./cluster.yml
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
 
-      - name: Dry Run Helm
+      - name: Helm install (dry-run)
         run: |
-          helm install --dry-run ${{ inputs.helm-release-name }} ./todoapp-*.tgz  \
-          -f ${{ inputs.helm-values-path }} \
-          --set mysql.secrets.MYSQL_ROOT_PASSWORD="${{ secrets.MYSQL_ROOT_PASSWORD }}" \
-          --set mysql.secrets.MYSQL_USER="${{ secrets.MYSQL_USER }}" \
-          --set mysql.secrets.MYSQL_PASSWORD="${{ secrets.MYSQL_PASSWORD }}" \
-          --set todoapp.secrets.SECRET_KEY="${{ secrets.APP_SECRET_KEY }}" \
-          --set todoapp.secrets.DB_NAME="${{ secrets.APP_DB_NAME }}" \
-          --set todoapp.secrets.DB_USER="${{ secrets.MYSQL_USER }}" \
-          --set todoapp.secrets.DB_PASSWORD="${{ secrets.MYSQL_PASSWORD }}" \
-          --set todoapp.secrets.DB_HOST="${{ secrets.APP_DB_HOST }}" \
-          --set todoapp.image.tag=${{ github.sha }}
+          helm install ${{ inputs.helm-release-name }} ./todoapp-*.tgz \
+            -f ${{ inputs.helm-values-path }} \
+            --dry-run
 
-      - name: Deploy helm to Development
+      - name: Helm upgrade/install (atomic)
         run: |
-          helm upgrade --install --wait --timeout 180s --debug ${{ inputs.helm-release-name }} ./todoapp-*.tgz \
-          -f ${{ inputs.helm-values-path }} \
-          --set mysql.secrets.MYSQL_ROOT_PASSWORD="${{ secrets.MYSQL_ROOT_PASSWORD }}" \
-          --set mysql.secrets.MYSQL_USER="${{ secrets.MYSQL_USER }}" \
-          --set mysql.secrets.MYSQL_PASSWORD="${{ secrets.MYSQL_PASSWORD }}" \
-          --set todoapp.secrets.SECRET_KEY="${{ secrets.APP_SECRET_KEY }}" \
-          --set todoapp.secrets.DB_NAME="${{ secrets.APP_DB_NAME }}" \
-          --set todoapp.secrets.DB_USER="${{ secrets.MYSQL_USER }}" \
-          --set todoapp.secrets.DB_PASSWORD="${{ secrets.MYSQL_PASSWORD }}" \
-          --set todoapp.secrets.DB_HOST="${{ secrets.APP_DB_HOST }}" \
-          --set todoapp.image.tag=${{ github.sha }}
-
+          helm upgrade --install ${{ inputs.helm-release-name }} ./todoapp-*.tgz \
+            -f ${{ inputs.helm-values-path }} \
+            --atomic --wait --timeout 300s


### PR DESCRIPTION
CI/CD: додано Docker build, matrix-тести, manual-run, deploy до Kind

— Тепер у python-ci запускається матриця на Python 3.8/3.9 × Ubuntu/Windows
— Додано docker-ci для побудови й пушу образів на DockerHub
— Workflow можна стартувати вручну з вибором артефакту
— Конфігурація concurrency скасовує попередні запуски
— Protected branch main із обов’язковим PR і статус-чеком
— Environment staging із Required reviewers для деплою

Посилання на успішний run:
https://github.com/vhurna/devops_todolist_cicd_task_6_polish_pipeline/actions/runs/14938057193

Скріншоти:
https://drive.usercontent.google.com/download?id=1L4xVlXgmYiYAFcSAH_PSTq-PcU-zF3Ol&authuser=0
https://drive.usercontent.google.com/download?id=1wZrGKsFeGlPtik_E4zi57n3EeG4AVRUj&authuser=0
https://drive.usercontent.google.com/download?id=1abkOog9g1yL_WbEaSOHKFdmNqgbPHMb7&authuser=0
https://drive.usercontent.google.com/download?id=10D15p7trC8wWcZARhpIwXA2YZiFyDoSz&authuser=0
https://drive.usercontent.google.com/download?id=1iDxPB4FalRTcrPgFdrIzZ7V9bnr3mnko&authuser=0
https://drive.usercontent.google.com/download?id=10-dp1mfnO0nOaBXRyzRe0za1c7hfuv6j&authuser=0
